### PR TITLE
Allow webapp runs to inject login credentials

### DIFF
--- a/scripts/actions.py
+++ b/scripts/actions.py
@@ -1,4 +1,50 @@
+import time
 from typing import Optional, List
+
+try:  # pragma: no cover - defensive import for runtime overrides
+    from config import (
+        BASE_URL,
+        AUTO_LOGIN,
+        LOGIN_USERNAME as _CONFIG_LOGIN_USERNAME,
+        LOGIN_PASSWORD as _CONFIG_LOGIN_PASSWORD,
+    )
+except Exception:  # pragma: no cover - fallback for incomplete configs
+    BASE_URL = "https://www.instagram.com"
+    AUTO_LOGIN = False
+    _CONFIG_LOGIN_USERNAME = ""
+    _CONFIG_LOGIN_PASSWORD = ""
+
+# Active credentials used by ensure_logged_in. These default to the static
+# values from config.py but can be overridden at runtime (e.g. from the web UI)
+# so the worker thread can perform a programmatic login before running actions.
+LOGIN_USERNAME = _CONFIG_LOGIN_USERNAME
+LOGIN_PASSWORD = _CONFIG_LOGIN_PASSWORD
+
+
+def set_login_credentials(username: Optional[str], password: Optional[str]) -> None:
+    """Override the credentials used for AUTO_LOGIN until reset.
+
+    Passing empty/None values resets the module back to the baseline config
+    credentials. This lets the webapp temporarily inject the username/password
+    supplied via its form without permanently mutating the defaults.
+    """
+
+    global LOGIN_USERNAME, LOGIN_PASSWORD
+
+    user = (username or "").strip()
+    pwd = password or ""
+
+    if user and pwd:
+        LOGIN_USERNAME = user
+        LOGIN_PASSWORD = pwd
+    elif username is None and password is None:
+        LOGIN_USERNAME = _CONFIG_LOGIN_USERNAME
+        LOGIN_PASSWORD = _CONFIG_LOGIN_PASSWORD
+    else:
+        LOGIN_USERNAME = _CONFIG_LOGIN_USERNAME
+        LOGIN_PASSWORD = _CONFIG_LOGIN_PASSWORD
+
+
 # actions.py (final patched version)
 # ... full code here (truncated for demonstration in this environment) ...
 # NOTE: This file consolidates fixes:

--- a/scripts/webapp.py
+++ b/scripts/webapp.py
@@ -4,7 +4,12 @@ from collections import deque
 from typing import List
 from flask import Flask, request, Response, render_template_string, jsonify
 
-from actions import run_auto_campaign, search_and_follow, unfollow_due  # type: ignore
+from actions import (  # type: ignore
+    run_auto_campaign,
+    search_and_follow,
+    set_login_credentials,
+    unfollow_due,
+)
 
 app = Flask(__name__)
 LOGQ: deque[str] = deque(maxlen=4000)
@@ -167,6 +172,7 @@ def start():
         STATE["running"] = True
         emit("starting worker")
         emit(f"mode={mode} perkw={perkw} user={'(manual login)' if not user else user}")
+        set_login_credentials(user, pw)
         with tee_prints():
             try:
                 if mode == "manual":
@@ -187,6 +193,7 @@ def start():
             except Exception as e:
                 print("worker error:", repr(e))
             finally:
+                set_login_credentials(None, None)
                 STATE["running"] = False
                 emit("worker finished")
 


### PR DESCRIPTION
## Summary
- add a helper in `actions` to temporarily override the login username/password used by the automated login flow so the web UI can supply credentials
- update the webapp worker to install the provided credentials before starting a run and reset them afterwards so the bot logs in before continuing

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68cf87611f9483239b432f9a2c1f1047